### PR TITLE
docs: improved with release v2.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ jobs:
         run: npm install
 
       - name: Run CodeGuardian scanner (CI mode)
-        run: npx codeguardian --ci
+        run: @shivam-sharma/codeguardian --ci
 ```
 
 When run with `--ci` the CLI exits with a non-zero code if any findings are detected — this will fail the job and block merges until issues are resolved.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shivam-sharma/codeguardian",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shivam-sharma/codeguardian",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shivam-sharma/codeguardian",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "CLI to scan repos for sensitive secrets before pushing",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
fixes the following issue

```bash
npm error code E404
npm error 404 Not Found - GET [https://registry.npmjs.org/codeguardian](vscode-file://vscode-app/c:/Users/shivams/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Not found
npm error 404
npm error 404 The requested resource 'codeguardian@*' could not be found or you do not have permission to access it.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-11T08_45_34_559Z-debug-0.log
Error: Process completed with exit code 1.
```